### PR TITLE
fix deprecation warning about Buffer()

### DIFF
--- a/Civ6Save-analysis/Civ6Save-structure.md
+++ b/Civ6Save-analysis/Civ6Save-structure.md
@@ -6,7 +6,7 @@ ByteLength | Type | Purpose | DefaultValue
 --- | --- | --- | ---
 4 | String | File Header | "CIV6"
 4 | Int32 | ? | 0x01?
-4 | Int32 | ? | 0x20?
+4 | Int32 | ? | 0x20 - 0x22?
 4 | Int32 | ? | 0x05d9b099?
 4 | Int32 | ? | 0x05?
 8 | ? | GAME_SPEED String Length | N/A

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const zlib = require('zlib');
 function decompress(savefile) {
   const civsav = savefile;
   const modindex = civsav.lastIndexOf('MOD_TITLE');
-  const bufstartindex = civsav.indexOf(new Buffer([0x78, 0x9c]), modindex);
-  const bufendindex = civsav.lastIndexOf(new Buffer([0x00, 0x00, 0xFF, 0xFF]));
+  const bufstartindex = civsav.indexOf(Buffer.from([0x78, 0x9c]), modindex);
+  const bufendindex = civsav.lastIndexOf(Buffer.from([0x00, 0x00, 0xFF, 0xFF]));
 
   const data = civsav.slice(bufstartindex, bufendindex);
 
@@ -23,7 +23,7 @@ function decompress(savefile) {
   }
   const compressedData = Buffer.concat(chunks);
 
-  const decompressed = zlib.inflateSync(compressedData, {finishFlush: zlib.Z_SYNC_FLUSH});
+  const decompressed = zlib.inflateSync(compressedData, { finishFlush: zlib.Z_SYNC_FLUSH });
 
   return decompressed;
 }
@@ -37,7 +37,7 @@ function decompress(savefile) {
 function recompress(savefile, binfile) {
   // We need to insert an extra 4 bytes every 64 * 1024 bytes of data to indicate length of the upcoming chunk
 
-  const compressedBuffer = zlib.deflateSync(binfile, {finishFlush: zlib.Z_SYNC_FLUSH});
+  const compressedBuffer = zlib.deflateSync(binfile, { finishFlush: zlib.Z_SYNC_FLUSH });
   const length = compressedBuffer.length;
   const CHUNK_LENGTH = 64 * 1024;
   const chunks = [];
@@ -45,7 +45,7 @@ function recompress(savefile, binfile) {
   for (let i = 0; i < length; i += CHUNK_LENGTH) {
     const slice = compressedBuffer.slice(i, i + CHUNK_LENGTH);
     if (i !== 0) {
-      let intbuf = new Buffer(4);
+      let intbuf = Buffer.alloc(4);
       intbuf.writeInt32LE(slice.length);
       chunks.push(intbuf);
     }
@@ -62,8 +62,8 @@ function recompress(savefile, binfile) {
   const modindex = civsav.lastIndexOf('MOD_TITLE');
 
   // Hex sequence 78 9c indicates the beginning of a zlib compressed buffer, and 00 00 FF FF indicates  the end
-  const bufstartindex = civsav.indexOf(new Buffer([0x78, 0x9c]), modindex);
-  const bufendindex = civsav.lastIndexOf(new Buffer([0x00, 0x00, 0xFF, 0xFF])) + 4;
+  const bufstartindex = civsav.indexOf(Buffer.from([0x78, 0x9c]), modindex);
+  const bufendindex = civsav.lastIndexOf(Buffer.from([0x00, 0x00, 0xFF, 0xFF])) + 4;
 
   const merged = Buffer.concat([civsav.slice(0, bufstartindex), finalBuffer, civsav.slice(bufendindex)]);
 
@@ -90,7 +90,7 @@ function modify(savefile, callback = (x => x)) {
  */
 function modifytiles(savefile, callback = (b => b)) {
   return modify(savefile, bin => {
-    const searchBuffer = new Buffer([0x0E, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00]);
+    const searchBuffer = Buffer.from([0x0E, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00]);
     const mapstartindex = bin.indexOf(searchBuffer);
     const tiles = bin.readInt32LE(mapstartindex + 12);
 
@@ -107,7 +107,7 @@ function modifytiles(savefile, callback = (b => b)) {
       const newtilebuf = callback(tilebuf);
       newtilebuf.copy(bin, mindex);
 
-      mindex += 55 + buflength;      
+      mindex += 55 + buflength;
     }
 
     return bin;
@@ -134,19 +134,19 @@ function verifyextension(filename, extension = '.Civ6Save') {
  */
 function savetomapjson(savefile) {
   const mapsizedata = {
-    '1144': {x: 44, y: 26},
-    '2280': {x: 60, y: 38},
-    '3404': {x: 74, y: 46},
-    '4536': {x: 84, y: 54},
-    '5760': {x: 96, y: 60},
-    '6996': {x: 106, y: 66},
+    '1144': { x: 44, y: 26 },
+    '2280': { x: 60, y: 38 },
+    '3404': { x: 74, y: 46 },
+    '4536': { x: 84, y: 54 },
+    '5760': { x: 96, y: 60 },
+    '6996': { x: 106, y: 66 },
   }
 
   const bin = decompress(savefile);
-  const searchBuffer = new Buffer([0x0E, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00]);
+  const searchBuffer = Buffer.from([0x0E, 0x00, 0x00, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00]);
   const mapstartindex = bin.indexOf(searchBuffer);
   const tiles = bin.readInt32LE(mapstartindex + 12);
-  const map = {'tiles': []};
+  const map = { 'tiles': [] };
 
   let mindex = mapstartindex + 16;
 

--- a/scripts/stringsplitter.js
+++ b/scripts/stringsplitter.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+
+if (!process.argv[2]) {
+  console.log("# stringsplitter.js usage:");
+  console.log("node stringsplitter.js [filename] [output.json]");
+  console.log("# writes JSON with hex addresses as keys and strings as values (default: [filename].json)");
+  process.exit();
+}
+
+const inputPath = process.argv[2];
+const outputPath = process.argv[3] || inputPath + '.json';
+
+// Read the binary file
+const buffer = fs.readFileSync(inputPath);
+
+// Fixed 6-byte suffix pattern: 00 21 01 00 00 00
+const SUFFIX = Buffer.from([0x00, 0x21, 0x01, 0x00, 0x00, 0x00]);
+
+// Find all occurrences of the suffix pattern
+const headerStarts = [];
+let lastIndex = 0;
+
+while (true) {
+  const index = buffer.indexOf(SUFFIX, lastIndex);
+  if (index === -1) {
+    break;
+  }
+  
+  // Header start is 2 bytes before the suffix (since pattern is bytes 2-7 of 8-byte header)
+  if (index >= 2) {
+    headerStarts.push(index - 2);
+  }
+  
+  lastIndex = index + 1;
+}
+
+// Build the map: hex address -> string
+const result = {};
+
+if (headerStarts.length === 0) {
+  // No matches found, return empty object
+  fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
+  process.exit();
+}
+
+// Process each header start
+for (let i = 0; i < headerStarts.length; i++) {
+  const headerStart = headerStarts[i];
+  const hexAddress = headerStart.toString(16);
+  
+  // Read the length from bytes 0-1 of the header (little-endian uint16)
+  const stringLength = buffer.readUInt16LE(headerStart);
+  const stringStart = headerStart + 8; // After the 8-byte header
+  const stringEnd = Math.min(stringStart + stringLength, buffer.length); // Use length, but don't exceed buffer
+  
+  // Extract the string bytes and decode as UTF-8
+  const stringBytes = buffer.subarray(stringStart, stringEnd);
+  const stringValue = stringBytes.toString('utf8');
+  
+  result[hexAddress] = stringValue;
+}
+
+// Output the result as JSON to file
+fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));


### PR DESCRIPTION
Running all scripts that require index.js will create a deprecation warning about the use of Buffer().

See similar thread https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues

This PR fixes that (and adds readability spaces)